### PR TITLE
extend pinning functionality

### DIFF
--- a/autoload/pinwindow.vim
+++ b/autoload/pinwindow.vim
@@ -29,9 +29,12 @@ export class PinWindow extends basewindow.BaseWindow
 
     def _LoadPaths() # {{{
         if !g:poplar.filename->filereadable()
+            v:errors->add($'ERROR, {g:poplar.filename} not readable.')
             return
         endif
         var paths = g:poplar.filename->readfile()
+        v:errors->add('paths found:')
+        v:errors->extend(paths)
         this._valid = []
         this._invalid = []
         for path in paths

--- a/autoload/pinwindow.vim
+++ b/autoload/pinwindow.vim
@@ -29,12 +29,9 @@ export class PinWindow extends basewindow.BaseWindow
 
     def LoadPaths() # {{{
         if !g:poplar.filename->filereadable()
-            v:errors->add($'ERROR, {g:poplar.filename} not readable.')
             return
         endif
         var paths = g:poplar.filename->readfile()
-        v:errors->add('paths found:')
-        v:errors->extend(paths)
         this._valid = []
         this._invalid = []
         for path in paths
@@ -169,13 +166,7 @@ export class PinWindow extends basewindow.BaseWindow
         # ----------------------- only in modify mode ------------------------
         if this._show_modify_mode
             if this._IsKey(key, g:poplar.keys.PIN_ADD)
-                var text = ''
-                if idx >= 0
-                    var info = this._GetPathIdxFromIdx(idx)
-                    if info.idx >= 0
-                        text = info.valid ? this._valid[info.idx] : this._invalid[info.idx]
-                    endif
-                endif
+                var text = getcwd()[-1] == '/' ? getcwd() : getcwd() .. '/'
                 inputline.Open(text, 'add a pin', this._CallbackPin, this.ToggleModifyMode)
             elseif idx >= 0 && this._IsKey(key, g:poplar.keys.PIN_MODIFY)
                 var info = this._GetPathIdxFromIdx(idx)

--- a/autoload/pinwindow.vim
+++ b/autoload/pinwindow.vim
@@ -12,7 +12,6 @@ export class PinWindow extends basewindow.BaseWindow
             this._CallbackSwitchFocus,
             this._CallbackExit)
         this._InitHelpText()
-        # this.LoadPaths()
     enddef
 
 

--- a/autoload/pinwindow.vim
+++ b/autoload/pinwindow.vim
@@ -12,7 +12,7 @@ export class PinWindow extends basewindow.BaseWindow
             this._CallbackSwitchFocus,
             this._CallbackExit)
         this._InitHelpText()
-        this._LoadPaths()
+        # this.LoadPaths()
     enddef
 
 
@@ -27,7 +27,7 @@ export class PinWindow extends basewindow.BaseWindow
     enddef
 
 
-    def _LoadPaths() # {{{
+    def LoadPaths() # {{{
         if !g:poplar.filename->filereadable()
             v:errors->add($'ERROR, {g:poplar.filename} not readable.')
             return
@@ -96,13 +96,13 @@ export class PinWindow extends basewindow.BaseWindow
         var paths = this._valid + this._invalid
         if g:poplar.filename->filereadable()
             try
-                paths->writefile(g:poplar.filename)
+                paths->writefile(g:poplar.filename, 's')
             catch
                 this._LogErr($'unable to write to {g:poplar.filename}')
             endtry
         elseif !paths->empty()
             try
-                paths->writefile(g:poplar.filename)
+                paths->writefile(g:poplar.filename, 's')
                 this._Log($'created new poplar list: {g:poplar.filename}.')
             catch
                 this._LogErr($'unable to write to {g:poplar.filename}')

--- a/autoload/poplar.vim
+++ b/autoload/poplar.vim
@@ -135,6 +135,51 @@ export def Run()
 enddef
 
 
+export def PinFile(arg: string = '')
+    var path = arg->trim() == ''
+            ? '%:p'->expand()
+            : arg->trim()->simplify()->fnamemodify(':p')
+    if !path->filereadable()
+        echohl ErrorMsg
+        echomsg $'[poplar] invalid file: {path}.'
+        echohl None
+        return
+    endif
+    if !g:poplar.filename->filereadable()
+        inputsave()
+        var resp = input($"[poplar] couldn't find {g:poplar.filename}. Create {g:poplar.filename}? (y/N) ")
+        inputrestore()
+        redraw
+        if resp->trim() !=? 'y'
+            echomsg '[poplar] aborted.'
+            return
+        else
+            try
+                []->writefile(g:poplar.filename, 'a')
+            catch
+                echohl ErrorMsg
+                echomsg $'[poplar] could not write to {g:poplar.filename}.'
+                echohl None
+                return
+            endtry
+        endif
+    endif
+    var saved = g:poplar.filename->readfile()
+    if saved->index(path) >= 0
+        echomsg $'[poplar] {path} already present in {g:poplar.filename}.'
+    else
+        try
+            [path]->writefile(g:poplar.filename, 'a')
+            echomsg $'[poplar] added a pin to {path}.'
+        catch
+            echohl ErrorMsg
+            echomsg $'[poplar] could not write to {g:poplar.filename}.'
+            echohl None
+        endtry
+    endif
+enddef
+
+
 def SwitchFocus(): bool
     var opts1 = (<TW.TreeWindow>g:poplar.tree_win).GetId()->popup_getoptions()
     var opts2 = (<PW.PinWindow>g:poplar.pin_win).GetId()->popup_getoptions()

--- a/autoload/poplar.vim
+++ b/autoload/poplar.vim
@@ -147,7 +147,7 @@ export def PinFile(arg: string = '')
     endif
     if !g:poplar.filename->filereadable()
         inputsave()
-        var resp = input($"[poplar] couldn't find {g:poplar.filename}. Create {g:poplar.filename}? (y/N) ")
+        var resp = input($"[poplar] create {g:poplar.filename}? (y/N) ")
         inputrestore()
         redraw
         if resp->trim() !=? 'y'

--- a/autoload/poplar.vim
+++ b/autoload/poplar.vim
@@ -120,6 +120,7 @@ export def Run()
     (<TW.TreeWindow>g:poplar.tree_win).Open(' poplar ')
     (<PW.PinWindow>g:poplar.pin_win).Open(' pinned ')
     (<PW.PinWindow>g:poplar.pin_win).LoadPaths()
+    (<PW.PinWindow>g:poplar.pin_win).HardRefresh()
 
     if (<TW.TreeWindow>g:poplar.tree_win).savestate->empty()
         (<TW.TreeWindow>g:poplar.tree_win).GetId()->popup_setoptions({

--- a/autoload/poplar.vim
+++ b/autoload/poplar.vim
@@ -155,7 +155,7 @@ export def PinFile(arg: string = '')
             return
         else
             try
-                []->writefile(g:poplar.filename, 'a')
+                []->writefile(g:poplar.filename, 'as')
             catch
                 echohl ErrorMsg
                 echomsg $'[poplar] could not write to {g:poplar.filename}.'
@@ -169,7 +169,7 @@ export def PinFile(arg: string = '')
         echomsg $'[poplar] {path} already present in {g:poplar.filename}.'
     else
         try
-            [path]->writefile(g:poplar.filename, 'a')
+            [path]->writefile(g:poplar.filename, 'as')
             echomsg $'[poplar] added a pin to {path}.'
         catch
             echohl ErrorMsg

--- a/autoload/poplar.vim
+++ b/autoload/poplar.vim
@@ -119,6 +119,7 @@ export def Run()
 
     (<TW.TreeWindow>g:poplar.tree_win).Open(' poplar ')
     (<PW.PinWindow>g:poplar.pin_win).Open(' pinned ')
+    (<PW.PinWindow>g:poplar.pin_win).LoadPaths()
 
     if (<TW.TreeWindow>g:poplar.tree_win).savestate->empty()
         (<TW.TreeWindow>g:poplar.tree_win).GetId()->popup_setoptions({

--- a/autoload/treewindow.vim
+++ b/autoload/treewindow.vim
@@ -105,8 +105,10 @@ export class TreeWindow extends basewindow.BaseWindow
                 this._tree.ChangeRoot(node)
                 this.SetLines(this._tree.GetPrettyFormatLines())
             elseif this._IsKey(key, g:poplar.keys.TREE_TOGGLE_PIN)
-                if !(node.path->filereadable())
-                    this._LogErr($'cannot pin {node.path}')
+                if node.path->isdirectory()
+                    this._LogErr($'cannot pin {node.path}: is a directory!')
+                elseif !(node.path->filereadable())
+                    this._LogErr($'cannot pin {node.path}: not a readable file!')
                 else
                     this._pin_callbacks.TogglePin(node.path)
                 endif

--- a/plugin/poplar.vim
+++ b/plugin/poplar.vim
@@ -14,3 +14,4 @@ import autoload '../autoload/poplar.vim'
 highlight! PoplarInv cterm=inverse gui=inverse
 
 command! Poplar poplar.Run()
+command! -nargs=? -complete=file PoplarPin poplar.PinFile(<f-args>)


### PR DESCRIPTION
- can now call `:PoplarPin` to pin the current file, or `:PoplarPin {file}` to pin `{file}`.
- to accommodate the above, pin window now loads the save file and refreshes upon opening.
- trying to pin a directory vs an unreadable file from the tree window now give different errors.