### PR TITLE
allow poplar to mv an untracked dir

### DIFF
--- a/autoload/treewindow.vim
+++ b/autoload/treewindow.vim
@@ -243,7 +243,7 @@ export class TreeWindow extends basewindow.BaseWindow
 
             dest = dest[-1] == '/' ? dest : dest .. '/'
 
-            var try_git_mv = g:poplar.usegitcmds && util.IsInsideGitTree()
+            var try_git_mv = g:poplar.usegitcmds && util.IsInsideGitTree() && util.FileIsTracked(from)
             var exitcode = -1
             if try_git_mv
                 g:poplar.output = $'git mv {from} {dest}'->system()->trim()

--- a/autoload/util.vim
+++ b/autoload/util.vim
@@ -125,6 +125,12 @@ export def IsInsideGitTree(): bool
 enddef
 
 
+export def FileIsTracked(filename: string): bool
+    # assumes IsInsideGitTree
+    return $"{('git ls-files ' .. filename)->system()->trim()}" != ''
+enddef
+
+
 export def GetGitBranchName(): string
     if IsInsideGitTree()
         var branch = 'git symbolic-ref --short HEAD'->system()->trim()


### PR DESCRIPTION
fixes #5 

previously, if `g:poplar.usegitcmds` and the user is inside a git tree, poplar would use `git mv` to move directories. since `git mv` can't move untracked directories, it meant that a untracked directory would not get moved.