### PR TITLE
fix: make compatiable with windows-style paths

### DIFF
--- a/autoload/filetree.vim
+++ b/autoload/filetree.vim
@@ -163,7 +163,15 @@ export class FileTree
             this._expanded_paths[node.path] = null_string
         endif
         if node.children == null_list
-            var fmt_path = node.path == '/' ? node.path : $'{node.path}/'
+            var fmt_path: string = ''
+            # make compatiable with Windows-style paths
+            if has('win32') || has('win64')
+                var slash = &shellslash ? '/' : '\'
+                fmt_path = node.path =~ '^[A-Z]:\\$' ? node.path : node.path .. slash
+            else
+                fmt_path = node.path == '/' ? node.path : $'{node.path}/'
+            endif
+
             var listings = node.path->readdir()->map((_, p) => fmt_path .. p)
             var dirs = listings->copy()
                     ->filter((_, p) => p->isdirectory())


### PR DESCRIPTION
When i use poplar under linux system, everything is ok. But when windows, i found that git status not show. I found that the function ToggleDir in filetree.vim doesn't check os and just add '/' at the path end. This makes the code `this._git_status->get(node.path, '')` always get ''. This patch only add os check and make it compatiable with windows-style paths